### PR TITLE
Fix error when spaces are present in path

### DIFF
--- a/chrupd.cmd
+++ b/chrupd.cmd
@@ -1,6 +1,6 @@
 <# :
 @echo off
-SETLOCAL & SET "PS_BAT_ARGS=%~dp0 %*"
+SETLOCAL & SET PS_BAT_ARGS="%~dp0" %*
 IF DEFINED PS_BAT_ARGS SET "PS_BAT_ARGS=%PS_BAT_ARGS:"="""%"
 ENDLOCAL & powershell.exe -NoLogo -NoProfile -Command "&(Invoke-Command {[ScriptBlock]::Create('$Args = @( &{$Args} %PS_BAT_ARGS% );'+[String]::Join([char]10,(Get-Content \"%~f0\")))})"
 GOTO :EOF
@@ -49,7 +49,7 @@ If ( $(Try { (Test-Path variable:local:scriptDir) -And (&Test-Path $scriptDir) -
 	$scriptDir = ($ExecutionContext.SessionState.Path.GetUnresolvedProviderPathFromPSPath('.\'))
 }
 
-$logFile = $scriptDir + "\chrupd.log"
+$logFile = $scriptDir + "chrupd.log"
 $scriptName = "Simple Chromium Updater"; $scriptCmd = "chrupd.cmd"
 $installLog = "$env:TEMP\chromium_installer.log"
 $checkSite = "chromium.woolyss.com"

--- a/chrupd.cmd
+++ b/chrupd.cmd
@@ -1,6 +1,6 @@
 <# :
 @echo off
-SETLOCAL & SET PS_BAT_ARGS="%~dp0" %*
+SETLOCAL & SET PS_BAT_ARGS="%~dp0 %*"
 IF DEFINED PS_BAT_ARGS SET "PS_BAT_ARGS=%PS_BAT_ARGS:"="""%"
 ENDLOCAL & powershell.exe -NoLogo -NoProfile -Command "&(Invoke-Command {[ScriptBlock]::Create('$Args = @( &{$Args} %PS_BAT_ARGS% );'+[String]::Join([char]10,(Get-Content \"%~f0\")))})"
 GOTO :EOF


### PR DESCRIPTION
If there are spaces in the directory (i.e. "Program Files (x86)), the batch file will interpret the characters after the space as a new command. I don't believe this really affects anything but it bothers me. This simple edit fixes that error.